### PR TITLE
docs: correct default value for emptyOptionsPlaceholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export function App() {
 | reverse                       | Flag to reverse option and check mark positon| `false`       |
 | selectionEffectColor          | Color for selection effect                  | None          |
 | optionsScrollIndicator        | Flag to show scroll indicator for options   | `true`        |
-| emptyOptionsPlaceholder       | Placeholder text when options is empty      | `true`        |
+| emptyOptionsPlaceholder       | Placeholder text when options is empty      | 'No Options'  |
 | emptySearchMsg                | Message when search results are empty       | "No options"  |
 | value                         | Currently selected value(s) `string` or `Array<string>`| None|
 | clearable                     | Flag to enable clearing of selection        | `true`       |


### PR DESCRIPTION
## Summary
- fix README default value for `emptyOptionsPlaceholder`

## Testing
- `yarn lint` *(fails: couldn't find node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684096f3722083339ed9b250c2abcc83